### PR TITLE
fix unlink device

### DIFF
--- a/SignalServiceKit/src/Messages/OWSMessageSender.m
+++ b/SignalServiceKit/src/Messages/OWSMessageSender.m
@@ -48,6 +48,7 @@
 #import "LKSessionRequestMessage.h"
 #import "LKSessionRestoreMessage.h"
 #import "LKDeviceLinkMessage.h"
+#import "LKUnlinkDeviceMessage.h"
 #import "LKAddressMessage.h"
 #import <AxolotlKit/AxolotlExceptions.h>
 #import <AxolotlKit/CipherMessage.h>
@@ -979,7 +980,8 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
     BOOL isGroupMessage = messageSend.thread.isGroupThread;
     BOOL isPublicChatMessage = isGroupMessage && ((TSGroupThread *)messageSend.thread).isPublicChat;
     BOOL isDeviceLinkMessage = [message isKindOfClass:LKDeviceLinkMessage.class];
-    if (isPublicChatMessage || isDeviceLinkMessage) {
+    BOOL isUnlinkDeviceMessage = [message isKindOfClass:LKUnlinkDeviceMessage.class];
+    if (isPublicChatMessage || isDeviceLinkMessage || isUnlinkDeviceMessage) {
         [self sendMessage:messageSend];
     } else {
         BOOL isSilentMessage = message.isSilent || [message isKindOfClass:LKEphemeralMessage.class] || [message isKindOfClass:OWSOutgoingSyncMessage.class];


### PR DESCRIPTION
### Description
The function of unlinking device was not actually working. The slave device would get a note to self message like "Please accept to enable messages to be synced across devices" instead. This PR fixes that issue. 
