### PR TITLE
Ensure generated PreKeyBundle is valid

### DIFF
--- a/SignalServiceKit/src/Loki/Database/OWSPrimaryStorage+Loki.h
+++ b/SignalServiceKit/src/Loki/Database/OWSPrimaryStorage+Loki.h
@@ -2,6 +2,8 @@
 #import <AxolotlKit/PreKeyRecord.h>
 #import <AxolotlKit/PreKeyBundle.h>
 #import <YapDatabase/YapDatabase.h>
+#import <Curve25519Kit/Ed25519.h>
+#import <AxolotlKit/AxolotlExceptions.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/SignalServiceKit/src/Loki/Database/OWSPrimaryStorage+Loki.m
+++ b/SignalServiceKit/src/Loki/Database/OWSPrimaryStorage+Loki.m
@@ -124,7 +124,7 @@
         @try {
             PreKeyBundle *preKeyBundle = [self generatePreKeyBundleForContact:pubKey forceClean:forceClean];
             if (![Ed25519 throws_verifySignature:preKeyBundle.signedPreKeySignature
-                                       publicKey:preKeyBundle.preKeyPublic
+                                       publicKey:preKeyBundle.identityKey.throws_removeKeyType
                                             data:preKeyBundle.signedPreKeyPublic]) {
                 @throw [NSException exceptionWithName:InvalidKeyException reason:@"KeyIsNotValidlySigned" userInfo:nil];
             }

--- a/SignalServiceKit/src/Loki/Database/OWSPrimaryStorage+Loki.m
+++ b/SignalServiceKit/src/Loki/Database/OWSPrimaryStorage+Loki.m
@@ -81,15 +81,16 @@
 
 #define LKPreKeyBundleCollection @"LKPreKeyBundleCollection"
 
-- (PreKeyBundle *)generatePreKeyBundleForContact:(NSString *)pubKey {
+- (PreKeyBundle *)generatePreKeyBundleForContact:(NSString *)pubKey forceClean:(BOOL)forceClean {
     // Check pre keys to make sure we have them
     [TSPreKeyManager checkPreKeys];
     
     ECKeyPair *_Nullable keyPair = self.identityManager.identityKeyPair;
     OWSAssertDebug(keyPair);
+    
 
     // Refresh the signed pre key if needed
-    if (self.currentSignedPreKey == nil) {
+    if (self.currentSignedPreKey == nil || forceClean) {
         SignedPreKeyRecord *signedPreKeyRecord = [self generateRandomSignedRecord];
         [signedPreKeyRecord markAsAcceptedByService];
         [self storeSignedPreKey:signedPreKeyRecord.Id signedPreKeyRecord:signedPreKeyRecord];
@@ -114,6 +115,27 @@
                                                   signedPreKeySignature:signedPreKey.signature
                                                             identityKey:keyPair.publicKey.prependKeyType];
     return bundle;
+}
+
+- (PreKeyBundle *)generatePreKeyBundleForContact:(NSString *)pubKey {
+    int failureCount = 0;
+    BOOL forceClean = NO;
+    while (failureCount < 3) {
+        @try {
+            PreKeyBundle *preKeyBundle = [self generatePreKeyBundleForContact:pubKey forceClean:forceClean];
+            if (![Ed25519 throws_verifySignature:preKeyBundle.signedPreKeySignature
+                                       publicKey:preKeyBundle.preKeyPublic
+                                            data:preKeyBundle.signedPreKeyPublic]) {
+                @throw [NSException exceptionWithName:InvalidKeyException reason:@"KeyIsNotValidlySigned" userInfo:nil];
+            }
+            return preKeyBundle;
+        } @catch (NSException *exception) {
+            failureCount ++;
+            forceClean = YES;
+        }
+    }
+    OWSLogWarn(@"[Loki] Failed to generate a valid PreKeyBundle for %@", pubKey);
+    return nil;
 }
 
 - (PreKeyBundle *_Nullable)getPreKeyBundleForContact:(NSString *)pubKey {


### PR DESCRIPTION
### Description
Make sure the PrekeyBundle is valid before it is sent. This fixes the issue that sometimes when we try to send a device link message for authorization, there can be a KeyIsNotValidSigned exception that fails the device linking. The code is learning from Android.
