### PR TITLE
Increase Message TTL

### DIFF
--- a/SignalServiceKit/src/Loki/API/LokiAPI.swift
+++ b/SignalServiceKit/src/Loki/API/LokiAPI.swift
@@ -43,7 +43,6 @@ public final class LokiAPI : NSObject {
 
     internal static var powDifficulty: UInt = 2
 
-    public static let defaultMessageTTL: UInt64 = 24 * 60 * 60 * 1000
     public static let deviceLinkUpdateInterval: TimeInterval = 20
     
     // MARK: Nested Types

--- a/SignalServiceKit/src/Loki/API/LokiMessage.swift
+++ b/SignalServiceKit/src/Loki/API/LokiMessage.swift
@@ -34,7 +34,7 @@ public struct LokiMessage {
             let wrappedMessage = try LokiMessageWrapper.wrap(message: signalMessage)
             let data = wrappedMessage.base64EncodedString()
             let destination = signalMessage.recipientID
-            var ttl = LokiAPI.defaultMessageTTL
+            var ttl = TTLUtilities.fallbackMessageTTL
             if let messageTTL = signalMessage.ttl, messageTTL > 0 { ttl = UInt64(messageTTL) }
             let isPing = signalMessage.isPing
             return LokiMessage(destination: destination, data: data, ttl: ttl, isPing: isPing)

--- a/SignalServiceKit/src/Loki/Messaging/LKAddressMessage.m
+++ b/SignalServiceKit/src/Loki/Messaging/LKAddressMessage.m
@@ -44,6 +44,6 @@
 }
 
 #pragma mark Settings
-- (uint)ttl { return 1 * kMinuteInMs; }
+- (uint)ttl { return (uint)[LKTTLUtilities getTTLFor:LKMessageTypeAddress]; }
 
 @end

--- a/SignalServiceKit/src/Loki/Messaging/LKDeviceLinkMessage.m
+++ b/SignalServiceKit/src/Loki/Messaging/LKDeviceLinkMessage.m
@@ -79,7 +79,7 @@
 }
 
 #pragma mark Settings
-- (uint)ttl { return 4 * kMinuteInMs; }
+- (uint)ttl { return (uint)[LKTTLUtilities getTTLFor:LKMessageTypeLinkDevice]; }
 - (BOOL)shouldSyncTranscript { return NO; }
 - (BOOL)shouldBeSaved { return NO; }
 

--- a/SignalServiceKit/src/Loki/Messaging/LKEphemeralMessage.m
+++ b/SignalServiceKit/src/Loki/Messaging/LKEphemeralMessage.m
@@ -13,6 +13,6 @@
 #pragma mark Settings
 - (BOOL)shouldSyncTranscript { return NO; }
 - (BOOL)shouldBeSaved { return NO; }
-- (uint)ttl { return 23 * kHourInMs; }
+- (uint)ttl { return (uint)[LKTTLUtilities getTTLFor:LKMessageTypeEphemeral]; }
 
 @end

--- a/SignalServiceKit/src/Loki/Messaging/LKFriendRequestMessage.m
+++ b/SignalServiceKit/src/Loki/Messaging/LKFriendRequestMessage.m
@@ -23,7 +23,7 @@
 }
 
 #pragma mark Settings
-- (uint)ttl { return 4 * kDayInMs; }
+- (uint)ttl { return (uint)[LKTTLUtilities getTTLFor:LKMessageTypeFriendRequest]; }
 - (BOOL)shouldSyncTranscript { return NO; }
 
 @end

--- a/SignalServiceKit/src/Loki/Messaging/LKSessionRequestMessage.m
+++ b/SignalServiceKit/src/Loki/Messaging/LKSessionRequestMessage.m
@@ -11,7 +11,7 @@
 }
 
 - (BOOL)shouldBeSaved { return NO; }
-- (uint)ttl { return 23 * kHourInMs; }
+- (uint)ttl { return (uint)[LKTTLUtilities getTTLFor:LKMessageTypeSessionRequest]; }
 
 #pragma mark Building
 - (nullable SSKProtoDataMessageBuilder *)dataMessageBuilder

--- a/SignalServiceKit/src/Loki/Messaging/LKUnlinkDeviceMessage.m
+++ b/SignalServiceKit/src/Loki/Messaging/LKUnlinkDeviceMessage.m
@@ -20,7 +20,7 @@
 }
 
 #pragma mark Settings
-- (uint)ttl { return 4 * kDayInMs; }
+- (uint)ttl { return (uint)[LKTTLUtilities getTTLFor:LKMessageTypeUnlinkDevice]; }
 - (BOOL)shouldSyncTranscript { return NO; }
 - (BOOL)shouldBeSaved { return NO; }
 

--- a/SignalServiceKit/src/Loki/Messaging/TTL.swift
+++ b/SignalServiceKit/src/Loki/Messaging/TTL.swift
@@ -1,0 +1,32 @@
+
+@objc(LKTTLUtilities)
+public final class TTLUtilities : NSObject {
+
+    /// If a message type specifies an invalid TTL, this will be used.
+    public static let fallbackMessageTTL: UInt64 = 4 * 24 * 60 * 60 * 1000
+
+    @objc(LKMessageType)
+    public enum MessageType : Int {
+        case address
+        case ephemeral
+        case friendRequest
+        case linkDevice
+        case regular
+        case sessionRequest
+        case typingIndicator
+        case unlinkDevice
+    }
+
+    @objc public static func getTTL(for messageType: MessageType) -> UInt64 {
+        switch messageType {
+        case .address: return 1 * kMinuteInMs
+        case .ephemeral: return 4 * kDayInMs - 1 * kHourInMs
+        case .friendRequest: return 4 * kDayInMs
+        case .linkDevice: return 4 * kMinuteInMs
+        case .sessionRequest: return 4 * kDayInMs - 1 * kHourInMs
+        case .regular: return 2 * kDayInMs
+        case .typingIndicator: return 1 * kMinuteInMs
+        case .unlinkDevice: return 4 * kDayInMs
+        }
+    }
+}

--- a/SignalServiceKit/src/Messages/Interactions/TSOutgoingMessage.m
+++ b/SignalServiceKit/src/Messages/Interactions/TSOutgoingMessage.m
@@ -1155,9 +1155,7 @@ NSString *NSStringForOutgoingMessageRecipientState(OWSOutgoingMessageRecipientSt
     return [result copy];
 }
 
-- (uint)ttl {
-    return 1 * kDayInMs; // TODO: Change this to return a value that the user chose
-}
+- (uint)ttl { return (uint)[LKTTLUtilities getTTLFor:LKMessageTypeRegular]; }
 
 @end
 

--- a/SignalServiceKit/src/Messages/TypingIndicatorMessage.swift
+++ b/SignalServiceKit/src/Messages/TypingIndicatorMessage.swift
@@ -101,7 +101,7 @@ public class TypingIndicatorMessage: TSOutgoingMessage {
     }
  
     @objc
-    public override var ttl: UInt32 { return UInt32(2 * kMinuteInMs) }
+    public override var ttl: UInt32 { return UInt32(TTLUtilities.getTTL(for: .typingIndicator)) }
 
     @objc
     public override var debugDescription: String {


### PR DESCRIPTION
Service nodes currently only storage messages for a day, so if a user sends a message to a second user, and that second user waits for more than a day before opening the app, the message won't be retrieved. This PR mitigates that problem a bit by simply increasing the message TTL.