### PR TITLE
Improve Message Fetching Performance

### DIFF
--- a/SignalServiceKit/src/Messages/OWSMessageManager.m
+++ b/SignalServiceKit/src/Messages/OWSMessageManager.m
@@ -1250,8 +1250,9 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     // Loki: Update device links in a blocking way
-    // TODO: This is pretty bad for performance...
-    // The envelope source is set during UD decryption.
+    // FIXME: This is horrible for performance
+    // FIXME: ========
+    // The envelope source is set during UD decryption
     if ([ECKeyPair isValidHexEncodedPublicKeyWithCandidate:envelope.source] && dataMessage.publicChatInfo == nil) { // Handled in LokiPublicChatPoller for open group messages
         dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
         [[LKMultiDeviceProtocol updateDeviceLinksIfNeededForHexEncodedPublicKey:envelope.source in:transaction].ensureOn(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^() {
@@ -1259,8 +1260,9 @@ NS_ASSUME_NONNULL_BEGIN
         }).catchOn(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(NSError *error) {
             dispatch_semaphore_signal(semaphore);
         }) retainUntilComplete];
-        dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, 10 * NSEC_PER_SEC));
+        dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, 4 * NSEC_PER_SEC));
     }
+    // FIXME: ========
 
     if (groupId.length > 0) {
         NSMutableSet *newMemberIds = [NSMutableSet setWithArray:dataMessage.group.members];


### PR DESCRIPTION
We're currently fetching device links in a blocking way during message processing. This is terrible for performance. To get rid of it we'll need to move to an alternative device link management system, for example the one proposed here: https://github.com/loki-project/session-protocol-docs/issues/1. This PR somewhat mitigates the problem for now by simply reducing the timeout on the device link fetch from 10 seconds to 4 seconds.