### PR TITLE
Fix closed group and contact syncing.

### DIFF
--- a/SignalServiceKit/src/Loki/Database/OWSPrimaryStorage+Loki.h
+++ b/SignalServiceKit/src/Loki/Database/OWSPrimaryStorage+Loki.h
@@ -62,9 +62,9 @@ typedef NS_ENUM(NSInteger, LKFriendRequestStatus) {
 
 # pragma mark - Friend Requests
 
+- (NSSet<NSString *> *)getAllFriendsWithTransaction:(YapDatabaseReadTransaction *)transaction NS_SWIFT_NAME(getAllFriends(using:));
 - (LKFriendRequestStatus)getFriendRequestStatusForContact:(NSString *)hexEncodedPublicKey transaction:(YapDatabaseReadTransaction *)transaction NS_SWIFT_NAME(getFriendRequestStatus(for:transaction:));
 - (void)setFriendRequestStatus:(LKFriendRequestStatus)friendRequestStatus forContact:(NSString *)hexEncodedPublicKey transaction:(YapDatabaseReadWriteTransaction *)transaction NS_SWIFT_NAME(setFriendRequestStatus(_:for:transaction:));
-
 
 @end
 

--- a/SignalServiceKit/src/Loki/Database/OWSPrimaryStorage+Loki.m
+++ b/SignalServiceKit/src/Loki/Database/OWSPrimaryStorage+Loki.m
@@ -226,6 +226,16 @@
 
 #define LKFriendRequestCollection @"LKFriendRequestCollection"
 
+- (NSSet<NSString *> *)getAllFriendsWithTransaction:(YapDatabaseReadTransaction *)transaction {
+    NSMutableSet<NSString *> *hexEncodedPublicKeys = [NSMutableSet set];
+    [transaction enumerateKeysAndObjectsInCollection:LKFriendRequestCollection usingBlock:^(NSString *hexEncodedPublicKey, NSNumber *status, BOOL * _Nonnull stop) {
+        if ([status integerValue] == LKFriendRequestStatusFriends) {
+            [hexEncodedPublicKeys addObject:hexEncodedPublicKey];
+        }
+    }];
+    return hexEncodedPublicKeys;
+}
+
 - (LKFriendRequestStatus)getFriendRequestStatusForContact:(NSString *)hexEncodedPublicKey transaction:(YapDatabaseReadTransaction *)transaction {
     NSNumber *_Nullable status = [transaction objectForKey:hexEncodedPublicKey inCollection:LKFriendRequestCollection];
     if (status == nil) { return LKFriendRequestStatusNone; }

--- a/SignalServiceKit/src/Loki/Database/OWSPrimaryStorage+Loki.m
+++ b/SignalServiceKit/src/Loki/Database/OWSPrimaryStorage+Loki.m
@@ -228,7 +228,7 @@
 
 - (NSSet<NSString *> *)getAllFriendsWithTransaction:(YapDatabaseReadTransaction *)transaction {
     NSMutableSet<NSString *> *hexEncodedPublicKeys = [NSMutableSet set];
-    [transaction enumerateKeysAndObjectsInCollection:LKFriendRequestCollection usingBlock:^(NSString *hexEncodedPublicKey, NSNumber *status, BOOL * _Nonnull stop) {
+    [transaction enumerateKeysAndObjectsInCollection:LKFriendRequestCollection usingBlock:^(NSString *hexEncodedPublicKey, NSNumber *status, BOOL *stop) {
         if ([status integerValue] == LKFriendRequestStatusFriends) {
             [hexEncodedPublicKeys addObject:hexEncodedPublicKey];
         }

--- a/SignalServiceKit/src/Loki/Protocol/Friend Requests/FriendRequestProtocol.swift
+++ b/SignalServiceKit/src/Loki/Protocol/Friend Requests/FriendRequestProtocol.swift
@@ -170,6 +170,8 @@ public final class FriendRequestProtocol : NSObject {
     @objc(shouldUpdateFriendRequestStatusFromMessage:)
     public static func shouldUpdateFriendRequestStatus(from message: TSOutgoingMessage) -> Bool {
         // The order of these checks matters
+        if (message.thread.isGroupThread()) { return false }
+        if (message.thread.contactIdentifier() == getUserHexEncodedPublicKey()) { return false }
         if (message as? DeviceLinkMessage)?.kind == .request { return true }
         if message is SessionRequestMessage { return false }
         return message is FriendRequestMessage
@@ -243,7 +245,7 @@ public final class FriendRequestProtocol : NSObject {
         // Signal cipher decryption and thus that we have a session with the other person.
         let friendRequestStatus = storage.getFriendRequestStatus(for: hexEncodedPublicKey, transaction: transaction);
         // We shouldn't be able to skip from none to friends
-        guard friendRequestStatus != .none else { return }
+        guard friendRequestStatus != .none && friendRequestStatus != .friends else { return }
         // Become friends
         storage.setFriendRequestStatus(.friends, for: hexEncodedPublicKey, transaction: transaction)
         // Send a contact sync message if needed

--- a/SignalServiceKit/src/Loki/Protocol/Friend Requests/FriendRequestProtocol.swift
+++ b/SignalServiceKit/src/Loki/Protocol/Friend Requests/FriendRequestProtocol.swift
@@ -170,8 +170,8 @@ public final class FriendRequestProtocol : NSObject {
     @objc(shouldUpdateFriendRequestStatusFromMessage:)
     public static func shouldUpdateFriendRequestStatus(from message: TSOutgoingMessage) -> Bool {
         // The order of these checks matters
-        if (message.thread.isGroupThread()) { return false }
-        if (message.thread.contactIdentifier() == getUserHexEncodedPublicKey()) { return false }
+        if message.thread.isGroupThread() { return false }
+        if message.thread.contactIdentifier() == getUserHexEncodedPublicKey() { return false }
         if (message as? DeviceLinkMessage)?.kind == .request { return true }
         if message is SessionRequestMessage { return false }
         return message is FriendRequestMessage
@@ -245,9 +245,8 @@ public final class FriendRequestProtocol : NSObject {
         // Signal cipher decryption and thus that we have a session with the other person.
         let friendRequestStatus = storage.getFriendRequestStatus(for: hexEncodedPublicKey, transaction: transaction);
         // We shouldn't be able to skip from none to friends
-        guard friendRequestStatus == .requestSending ||
-            friendRequestStatus == .requestSent ||
-            friendRequestStatus == .requestReceived else { return }
+        guard friendRequestStatus == .requestSending || friendRequestStatus == .requestSent
+            || friendRequestStatus == .requestReceived else { return }
         // Become friends
         storage.setFriendRequestStatus(.friends, for: hexEncodedPublicKey, transaction: transaction)
         // Send a contact sync message if needed

--- a/SignalServiceKit/src/Loki/Protocol/Friend Requests/FriendRequestProtocol.swift
+++ b/SignalServiceKit/src/Loki/Protocol/Friend Requests/FriendRequestProtocol.swift
@@ -245,7 +245,9 @@ public final class FriendRequestProtocol : NSObject {
         // Signal cipher decryption and thus that we have a session with the other person.
         let friendRequestStatus = storage.getFriendRequestStatus(for: hexEncodedPublicKey, transaction: transaction);
         // We shouldn't be able to skip from none to friends
-        guard friendRequestStatus != .none && friendRequestStatus != .friends else { return }
+        guard friendRequestStatus == .requestSending ||
+            friendRequestStatus == .requestSent ||
+            friendRequestStatus == .requestReceived else { return }
         // Become friends
         storage.setFriendRequestStatus(.friends, for: hexEncodedPublicKey, transaction: transaction)
         // Send a contact sync message if needed

--- a/SignalServiceKit/src/Loki/Protocol/Friend Requests/FriendRequestProtocolTests.swift
+++ b/SignalServiceKit/src/Loki/Protocol/Friend Requests/FriendRequestProtocolTests.swift
@@ -622,7 +622,6 @@ class FriendRequestProtocolTests : XCTestCase {
     }
 
     // MARK: - shouldUpdateFriendRequestStatus
-
     func test_shouldUpdateFriendRequestStatusReturnsTheCorrectValue() {
         let thread = LokiTestUtilities.createContactThread(for: LokiTestUtilities.generateHexEncodedPublicKey())
 

--- a/SignalServiceKit/src/Loki/Protocol/Friend Requests/FriendRequestProtocolTests.swift
+++ b/SignalServiceKit/src/Loki/Protocol/Friend Requests/FriendRequestProtocolTests.swift
@@ -622,6 +622,7 @@ class FriendRequestProtocolTests : XCTestCase {
     }
 
     // MARK: - shouldUpdateFriendRequestStatus
+
     func test_shouldUpdateFriendRequestStatusReturnsTheCorrectValue() {
         let thread = LokiTestUtilities.createContactThread(for: LokiTestUtilities.generateHexEncodedPublicKey())
 
@@ -636,5 +637,20 @@ class FriendRequestProtocolTests : XCTestCase {
         XCTAssertFalse(FriendRequestProtocol.shouldUpdateFriendRequestStatus(from: message))
         XCTAssertFalse(FriendRequestProtocol.shouldUpdateFriendRequestStatus(from: sessionRequest))
         XCTAssertFalse(FriendRequestProtocol.shouldUpdateFriendRequestStatus(from: deviceLinkAuthorisation))
+    }
+
+    func test_shouldUpdateFriendRequestStatusReturnsFalseForGroupThreads() {
+        let allGroupTypes: [GroupType] = [ .closedGroup, .openGroup, .rssFeed ]
+        for groupType in allGroupTypes {
+            guard let groupThread = LokiTestUtilities.createGroupThread(groupType: groupType) else { return XCTFail() }
+            let friendRequest = FriendRequestMessage(timestamp: 1, thread: groupThread, body: "")
+            XCTAssertFalse(FriendRequestProtocol.shouldUpdateFriendRequestStatus(from: friendRequest))
+        }
+    }
+
+    func test_shouldUpdateFriendRequestStatusReturnsFalseForCurrentDevice() {
+        let thread = LokiTestUtilities.createContactThread(for: LokiTestUtilities.getCurrentUserHexEncodedPublicKey())
+        let friendRequest = FriendRequestMessage(timestamp: 1, thread: thread, body: "")
+        XCTAssertFalse(FriendRequestProtocol.shouldUpdateFriendRequestStatus(from: friendRequest))
     }
 }

--- a/SignalServiceKit/src/Messages/OWSMessageSender.m
+++ b/SignalServiceKit/src/Messages/OWSMessageSender.m
@@ -383,6 +383,11 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
         [self.dbConnection readWriteWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
             [allAttachmentIds
                 addObjectsFromArray:[OutgoingMessagePreparer prepareMessageForSending:message transaction:transaction]];
+
+            // Loki - Optimistically update friend request status when we can
+            if ([LKFriendRequestProtocol shouldUpdateFriendRequestStatusFromMessage:message]) {
+                [LKFriendRequestProtocol setFriendRequestStatusToSendingIfNeededForHexEncodedPublicKey:message.thread.contactIdentifier transaction:transaction];
+            }
         }];
 
         NSOperationQueue *sendingQueue = [self sendingQueueForMessage:message];

--- a/SignalServiceKit/src/Messages/OWSMessageSender.m
+++ b/SignalServiceKit/src/Messages/OWSMessageSender.m
@@ -384,7 +384,8 @@ NSString *const OWSMessageSenderRateLimitedException = @"RateLimitedException";
             [allAttachmentIds
                 addObjectsFromArray:[OutgoingMessagePreparer prepareMessageForSending:message transaction:transaction]];
 
-            // Loki - Optimistically update friend request status when we can
+            // Loki: Optimistically update friend request status when we can. This is used for
+            // e.g. preventing AFRs from being sent twice on a contact sync.
             if ([LKFriendRequestProtocol shouldUpdateFriendRequestStatusFromMessage:message]) {
                 [LKFriendRequestProtocol setFriendRequestStatusToSendingIfNeededForHexEncodedPublicKey:message.thread.contactIdentifier transaction:transaction];
             }


### PR DESCRIPTION
We still have a problem where closed group members ignore session request because they don't have the latest device mappings.

This will be fixed by forcefully fetching device links if we got a friend request message. This fix will also cover the case where the friend request shows up in a seperate thread.