### PR TITLE
Update Seed Node Ports

### DIFF
--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -113,7 +113,7 @@
 	<key>NSContactsUsageDescription</key>
 	<string>Signal uses your contacts to find users you know. We do not store your contacts on the server.</string>
 	<key>NSFaceIDUsageDescription</key>
-	<string>Session&apos;s Screen Lock feature uses Face ID.</string>
+	<string>Session's Screen Lock feature uses Face ID.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Session needs access to your microphone to record videos.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>

--- a/Signal/Signal-Info.plist
+++ b/Signal/Signal-Info.plist
@@ -62,7 +62,7 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
-			<key>149.56.148.124</key>
+			<key>144.76.164.202</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
@@ -113,7 +113,7 @@
 	<key>NSContactsUsageDescription</key>
 	<string>Signal uses your contacts to find users you know. We do not store your contacts on the server.</string>
 	<key>NSFaceIDUsageDescription</key>
-	<string>Session's Screen Lock feature uses Face ID.</string>
+	<string>Session&apos;s Screen Lock feature uses Face ID.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Session needs access to your microphone to record videos.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>

--- a/SignalServiceKit/src/Loki/API/LokiAPI+SwarmAPI.swift
+++ b/SignalServiceKit/src/Loki/API/LokiAPI+SwarmAPI.swift
@@ -27,7 +27,7 @@ public extension LokiAPI {
     #if TESTNET
     fileprivate static let seedNodePool: Set<String> = [ "http://public.loki.foundation:38157" ]
     #else
-    fileprivate static let seedNodePool: Set<String> = [ "http://storage.seed1.loki.network:22023", "http://storage.seed2.loki.network:38157", "http://149.56.148.124:38157" ]
+    fileprivate static let seedNodePool: Set<String> = [ "http://storage.seed1.loki.network:22023", "http://storage.seed2.loki.network:22023", "http://144.76.164.202:22023" ]
     #endif
 
     internal static var randomSnodePool: Set<LokiAPITarget> = []

--- a/SignalShareExtension/Info.plist
+++ b/SignalShareExtension/Info.plist
@@ -26,7 +26,7 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
-			<key>149.56.148.124</key>
+			<key>144.76.164.202</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>


### PR DESCRIPTION
Replacing mainnet seed nodes with testnet port with the correct (now-working) correct mainnet port.
Kee wants to replace imaginary.seed due to SSL issues, it was using the IP, I've replaced it with the IP for public.loki.foundation for now.

But when we enable SSL, we'll need hosts. And for the dude having DNS issues with our seeds, we will either need to disable SSL verification or keep an http port open for him