### PR TITLE
PN Migration

### DIFF
--- a/SignalServiceKit/src/Loki/Utilities/LKUserDefaults.swift
+++ b/SignalServiceKit/src/Loki/Utilities/LKUserDefaults.swift
@@ -21,7 +21,6 @@ public enum LKUserDefaults {
     public enum Double : Swift.String {
         /// - Note: Deprecated
         case lastDeviceTokenUpload = "lastDeviceTokenUploadTime"
-        case lastDeviceTokenUpload2 = "lastDeviceTokenUpload2"
     }
 
     public enum Int: Swift.String {


### PR DESCRIPTION
The idea is that during the migration period, devices will start hitting the `notify` endpoint but it won't do anything yet. Other than that everything will be unchanged from before (except everything's now onion routed). Once enough users are hitting the `notify` endpoint, we switch everyone away from the polling approach to the new approach.