### PR TITLE
SSK Improvements Part 1

### DIFF
--- a/Signal/src/Loki/View Controllers/EditClosedGroupVC.swift
+++ b/Signal/src/Loki/View Controllers/EditClosedGroupVC.swift
@@ -22,6 +22,14 @@ final class EditClosedGroupVC : BaseVC, UITableViewDataSource, UITableViewDelega
         return result
     }()
 
+    private lazy var addMembersButton: Button = {
+            let result = Button(style: .prominentOutline, size: .large)
+            result.setTitle("Add Members", for: UIControl.State.normal)
+            result.addTarget(self, action: #selector(addMembers), for: UIControl.Event.touchUpInside)
+            result.contentEdgeInsets = UIEdgeInsets(top: 0, leading: Values.mediumSpacing, bottom: 0, trailing: Values.mediumSpacing)
+            return result
+        }()
+
     @objc private lazy var tableView: UITableView = {
         let result = UITableView()
         result.dataSource = self
@@ -56,13 +64,13 @@ final class EditClosedGroupVC : BaseVC, UITableViewDataSource, UITableViewDelega
         let backButton = UIBarButtonItem(title: "Back", style: .plain, target: nil, action: nil)
         backButton.tintColor = Colors.text
         navigationItem.backBarButtonItem = backButton
-        setUpViewHierarchy()
-        updateNavigationBarButtons()
-        name = thread.groupModel.groupName!
         func getDisplayName(for publicKey: String) -> String {
             return UserDisplayNameUtilities.getPrivateChatDisplayName(for: publicKey) ?? publicKey
         }
         members = GroupUtilities.getClosedGroupMembers(thread).sorted { getDisplayName(for: $0) < getDisplayName(for: $1) }
+        setUpViewHierarchy()
+        updateNavigationBarButtons()
+        name = thread.groupModel.groupName!
     }
 
     private func setUpViewHierarchy() {
@@ -88,11 +96,8 @@ final class EditClosedGroupVC : BaseVC, UITableViewDataSource, UITableViewDelega
         membersLabel.font = .systemFont(ofSize: Values.mediumFontSize)
         membersLabel.text = "Members"
         // Add members button
-        let addMembersButton = Button(style: .prominentOutline, size: .large)
-        addMembersButton.setTitle("Add Members", for: UIControl.State.normal)
-        addMembersButton.addTarget(self, action: #selector(addMembers), for: UIControl.Event.touchUpInside)
-        addMembersButton.contentEdgeInsets = UIEdgeInsets(top: 0, leading: Values.mediumSpacing, bottom: 0, trailing: Values.mediumSpacing)
-        if (Set(ContactUtilities.getAllContacts()).subtracting(members).isEmpty) {
+        let hasContactsToAdd = !Set(ContactUtilities.getAllContacts()).subtracting(self.members).isEmpty
+        if (!hasContactsToAdd) {
             addMembersButton.isUserInteractionEnabled = false
             let disabledColor = Colors.text.withAlphaComponent(Values.unimportantElementOpacity)
             addMembersButton.layer.borderColor = disabledColor.cgColor
@@ -222,6 +227,11 @@ final class EditClosedGroupVC : BaseVC, UITableViewDataSource, UITableViewDelega
                 return UserDisplayNameUtilities.getPrivateChatDisplayName(for: publicKey) ?? publicKey
             }
             self.members = members.sorted { getDisplayName(for: $0) < getDisplayName(for: $1) }
+            let hasContactsToAdd = !Set(ContactUtilities.getAllContacts()).subtracting(self.members).isEmpty
+            self.addMembersButton.isUserInteractionEnabled = hasContactsToAdd
+            let color = hasContactsToAdd ? Colors.accent : Colors.text.withAlphaComponent(Values.unimportantElementOpacity)
+            self.addMembersButton.layer.borderColor = color.cgColor
+            self.addMembersButton.setTitleColor(color, for: UIControl.State.normal)
         }
         navigationController!.pushViewController(userSelectionVC, animated: true, completion: nil)
     }

--- a/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewController.m
@@ -5398,13 +5398,13 @@ typedef enum : NSUInteger {
     }
     dispatch_async(dispatch_get_main_queue(), ^{
         __block TSInteraction *targetInteraction;
-        [LKStorage writeSyncWithBlock:^(YapDatabaseReadWriteTransaction *transaction) {
+        [LKStorage readWithBlock:^(YapDatabaseReadTransaction *transaction) {
             [self.thread enumerateInteractionsWithTransaction:transaction usingBlock:^(TSInteraction *interaction, YapDatabaseReadTransaction *t) {
                 if (interaction.timestampForUI == timestamp.unsignedLongLongValue) {
                     targetInteraction = interaction;
                 }
             }];
-        } error:nil];
+        }];
         if (targetInteraction == nil || targetInteraction.interactionType != OWSInteractionType_OutgoingMessage) { return; }
         NSString *hexEncodedPublicKey = targetInteraction.thread.contactIdentifier;
         if (hexEncodedPublicKey == nil) { return; }

--- a/SignalServiceKit/src/Loki/Protocol/Closed Groups/ClosedGroupUtilities.swift
+++ b/SignalServiceKit/src/Loki/Protocol/Closed Groups/ClosedGroupUtilities.swift
@@ -10,6 +10,7 @@ public final class ClosedGroupUtilities : NSObject {
         @objc public static let invalidGroupPublicKey = SSKDecryptionError(domain: "SSKErrorDomain", code: 1, userInfo: [ NSLocalizedDescriptionKey : "Invalid group public key." ])
         @objc public static let noData = SSKDecryptionError(domain: "SSKErrorDomain", code: 2, userInfo: [ NSLocalizedDescriptionKey : "Received an empty envelope." ])
         @objc public static let noGroupPrivateKey = SSKDecryptionError(domain: "SSKErrorDomain", code: 3, userInfo: [ NSLocalizedDescriptionKey : "Missing group private key." ])
+        @objc public static let selfSend = SSKDecryptionError(domain: "SSKErrorDomain", code: 4, userInfo: [ NSLocalizedDescriptionKey : "Message addressed at self." ])
     }
 
     @objc(encryptData:usingGroupPublicKey:transaction:error:)
@@ -59,6 +60,7 @@ public final class ClosedGroupUtilities : NSObject {
         // 4. ) Parse the closed group ciphertext message
         let closedGroupCiphertextMessage = ClosedGroupCiphertextMessage(_throws_with: closedGroupCiphertextMessageAsData)
         let senderPublicKey = closedGroupCiphertextMessage.senderPublicKey.toHexString()
+        guard senderPublicKey != getUserHexEncodedPublicKey() else { throw SSKDecryptionError.selfSend }
         // 5. ) Use the info inside the closed group ciphertext message to decrypt the actual message content
         let plaintext = try SharedSenderKeysImplementation.shared.decrypt(closedGroupCiphertextMessage.ivAndCiphertext, forGroupWithPublicKey: groupPublicKey,
             senderPublicKey: senderPublicKey, keyIndex: UInt(closedGroupCiphertextMessage.keyIndex), protocolContext: transaction)


### PR DESCRIPTION
### What's in this PR:

• The add members button in the edit closed group screen didn't always update properly after adding members to a group (it'd stay enabled even if you didn't have anyone left to add). This is now fixed :)
• Removed an unnecessary write transaction that may have been responsible for a few deadlocks.
• A bit of cleanup around SSK error handling.
• **Fixed a race condition that could cause you to miss messages just after someone is removed from a group.**
• **We now better handle SSK messages coming in out-of-order.**