### PR TITLE
Fix Attachment Downloading

### DIFF
--- a/Signal/src/ViewControllers/ConversationView/ConversationViewModel.m
+++ b/Signal/src/ViewControllers/ConversationView/ConversationViewModel.m
@@ -1235,6 +1235,18 @@ static const int kYapDatabaseRangeMaxLength = 25000;
               OWSAssertDebug(!viewItemCache[interaction.uniqueId]);
               viewItemCache[interaction.uniqueId] = viewItem;
               [viewItems addObject:viewItem];
+              TSMessage *message = (TSMessage *)viewItem.interaction;
+              if (message.hasAttachmentsInNSE) {
+                  [SSKEnvironment.shared.attachmentDownloads downloadAttachmentsForMessage:message
+                      transaction:transaction
+                      success:^(NSArray<TSAttachmentStream *> *attachmentStreams) {
+                          OWSLogInfo(@"Successfully redownloaded attachment in thread: %@", message.thread);
+                      }
+                      failure:^(NSError *error) {
+                          OWSLogWarn(@"Failed to redownload message with error: %@", error);
+                      }];
+              }
+              
 
               return viewItem;
           };

--- a/SignalServiceKit/src/Messages/Attachments/OWSAttachmentDownloads.m
+++ b/SignalServiceKit/src/Messages/Attachments/OWSAttachmentDownloads.m
@@ -290,6 +290,13 @@ typedef void (^AttachmentDownloadFailure)(NSError *error);
             [job.attachmentPointer saveWithTransaction:transaction];
 
             if (job.message) {
+                if (!CurrentAppContext().isMainApp) {
+                    job.message.hasAttachmentsInNSE = true;
+                } else {
+                    job.message.hasAttachmentsInNSE = false;
+                }
+                
+                [job.message saveWithTransaction:transaction];
                 [job.message touchWithTransaction:transaction];
             }
         }];

--- a/SignalServiceKit/src/Messages/Interactions/TSMessage.h
+++ b/SignalServiceKit/src/Messages/Interactions/TSMessage.h
@@ -34,6 +34,8 @@ NS_ASSUME_NONNULL_BEGIN
 // Open groups
 @property (nonatomic) uint64_t openGroupServerMessageID;
 @property (nonatomic, readonly) BOOL isOpenGroupMessage;
+// Attachments in NSE
+@property (nonatomic) BOOL hasAttachmentsInNSE;
 
 - (instancetype)initInteractionWithTimestamp:(uint64_t)timestamp inThread:(TSThread *)thread NS_UNAVAILABLE;
 

--- a/SignalServiceKit/src/Messages/OWSFailedAttachmentDownloadsJob.m
+++ b/SignalServiceKit/src/Messages/OWSFailedAttachmentDownloadsJob.m
@@ -3,6 +3,8 @@
 //
 
 #import "OWSFailedAttachmentDownloadsJob.h"
+#import "SSKEnvironment.h"
+#import "OWSAttachmentDownloads.h"
 #import "OWSPrimaryStorage.h"
 #import "TSAttachmentPointer.h"
 #import <YapDatabase/YapDatabase.h>
@@ -24,6 +26,12 @@ static NSString *const OWSFailedAttachmentDownloadsJobAttachmentStateIndex = @"i
 #pragma mark -
 
 @implementation OWSFailedAttachmentDownloadsJob
+
+- (OWSAttachmentDownloads *)attachmentDownloads
+{
+    return SSKEnvironment.shared.attachmentDownloads;
+}
+
 
 - (instancetype)initWithPrimaryStorage:(OWSPrimaryStorage *)primaryStorage
 {


### PR DESCRIPTION
The attachment downloads in NSE seems not to be working.
The NSE process ends earlier than the attachment downloads job.
So when in the main app, if the user goes to a conversation, just check if there are any attachments in NSE and retry downloading those attachments.
We may need more testing to see if there is any regression.