### PR TITLE
Fix Open Group Profile Picture Bug

### DIFF
--- a/Session/AppDelegate+OpenGroupAPI.swift
+++ b/Session/AppDelegate+OpenGroupAPI.swift
@@ -25,8 +25,15 @@ extension AppDelegate : OpenGroupAPIDelegate {
                     while sanitizedServerURL.hasSuffix("/") { sanitizedServerURL.removeLast(1) }
                     while sanitizedProfilePictureURL.hasPrefix("/") { sanitizedProfilePictureURL.removeFirst(1) }
                     let url = "\(sanitizedServerURL)/\(sanitizedProfilePictureURL)"
-                    FileServerAPI.downloadAttachment(from: url).map2 { data in
-                        let attachmentStream = TSAttachmentStream(contentType: OWSMimeTypeImageJpeg, byteCount: UInt32(data.count), sourceFilename: nil, caption: nil, albumMessageId: nil)
+                    FileServerAPI.downloadAttachment(from: url).map2 { srcData in
+                        let attachmentStream: TSAttachmentStream
+                        let data: Data
+                        if let srcImage = UIImage(data: srcData), let dstData = srcImage.jpegData(compressionQuality: 0.8) {
+                            data = dstData
+                        } else {
+                            data = srcData
+                        }
+                        attachmentStream = TSAttachmentStream(contentType: OWSMimeTypeImageJpeg, byteCount: UInt32(data.count), sourceFilename: nil, caption: nil, albumMessageId: nil)
                         try attachmentStream.write(data)
                         groupThread.updateAvatar(with: attachmentStream)
                     }

--- a/SignalUtilitiesKit/OWSThumbnailService.swift
+++ b/SignalUtilitiesKit/OWSThumbnailService.swift
@@ -168,7 +168,7 @@ private struct OWSThumbnailRequest {
             throw OWSThumbnailError.failure(description: "Could not convert thumbnail to JPEG.")
         }
         do {
-            try thumbnailData.write(to: URL(fileURLWithPath: thumbnailPath), options: .atomicWrite)
+            try thumbnailData.write(to: URL(fileURLWithPath: thumbnailPath, isDirectory: false), options: .atomic)
         } catch let error as NSError {
             throw OWSThumbnailError.externalError(description: "File write failed: \(thumbnailPath), \(error)", underlyingError: error)
         }

--- a/SignalUtilitiesKit/ProfilePictureView.swift
+++ b/SignalUtilitiesKit/ProfilePictureView.swift
@@ -60,11 +60,7 @@ public final class ProfilePictureView : UIView {
     public func update(for thread: TSThread) {
         openGroupProfilePicture = nil
         if let thread = thread as? TSGroupThread {
-            if thread.name() == "Loki Public Chat"
-                || thread.name() == "Session Public Chat" { // Override the profile picture for the Loki Public Chat and the Session Public Chat
-                hexEncodedPublicKey = ""
-                isRSSFeed = true
-            } else if let openGroupProfilePicture = thread.groupModel.groupImage { // An open group with a profile picture
+            if let openGroupProfilePicture = thread.groupModel.groupImage { // An open group with a profile picture
                 self.openGroupProfilePicture = openGroupProfilePicture
                 isRSSFeed = false
                 hasTappableProfilePicture = true


### PR DESCRIPTION
Convert open group avatar to jpg.
Use the remote avatar for Session Public Chat